### PR TITLE
feat(map): add fullscreen mode

### DIFF
--- a/config.js
+++ b/config.js
@@ -118,6 +118,7 @@ module.exports = {
       COLOR_BY_CATEGORY: false,
       COLOR_BY_ASSOCIATION: true,
       USE_ASSOCIATIONS: true,
+      USE_FULLSCREEN: true,
       USE_SOURCES: true,
       USE_SPOTLIGHTS: false,
       USE_SHAPES: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,6 +80,7 @@
         "resolve": "1.18.1",
         "resolve-url-loader": "^3.1.2",
         "sass-loader": "10.2.1",
+        "screenfull": "^5.2.0",
         "semver": "7.3.2",
         "style-loader": "1.3.0",
         "supercluster": "^7.1.0",
@@ -22138,6 +22139,17 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/screenfull": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz",
+      "integrity": "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/scriptjs": {
       "version": "2.5.9",
       "resolved": "https://registry.npmjs.org/scriptjs/-/scriptjs-2.5.9.tgz",
@@ -43297,6 +43309,11 @@
         "ajv": "^6.12.4",
         "ajv-keywords": "^3.5.2"
       }
+    },
+    "screenfull": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz",
+      "integrity": "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA=="
     },
     "scriptjs": {
       "version": "2.5.9",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "resolve": "1.18.1",
     "resolve-url-loader": "^3.1.2",
     "sass-loader": "10.2.1",
+    "screenfull": "^5.2.0",
     "semver": "7.3.2",
     "style-loader": "1.3.0",
     "supercluster": "^7.1.0",

--- a/src/common/data/copy.json
+++ b/src/common/data/copy.json
@@ -149,7 +149,9 @@
       "shapes": "Shapes",
       "shapes_label": "Shapes",
       "explore_by_shapes__title": "Explore events by shape breakdown",
-      "explore_by_shape__description": "Shapes map to a given type of event that appears on the timeline.<br><br>Select the shape marker to toggle this type of event on / off"
+      "explore_by_shape__description": "Shapes map to a given type of event that appears on the timeline.<br><br>Select the shape marker to toggle this type of event on / off",
+      "fullscreen_enter": "Fullscreen",
+      "fullscreen_exit": "Exit Fullscreen"
     },
     "timeline": {
       "labels_title": "Testimonies",

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -21,6 +21,7 @@ import {
   getCategoryIdxs,
   getFilterIdx,
 } from "../common/utilities.js";
+import { ToolbarButton } from "./controls/atoms/ToolbarButton";
 
 class Toolbar extends React.Component {
   constructor(props) {
@@ -179,20 +180,15 @@ class Toolbar extends React.Component {
   }
 
   renderToolbarTab(_selected, label, iconKey) {
-    const isActive = this.state._selected === _selected;
-    const classes = isActive ? "toolbar-tab active" : "toolbar-tab";
-
     return (
-      <div
-        className={classes}
-        key={iconKey}
+      <ToolbarButton
+        label={label}
+        iconKey={iconKey}
+        isActive={this.state._selected === _selected}
         onClick={() => {
           this.selectTab(_selected);
         }}
-      >
-        <i className="material-icons">{iconKey}</i>
-        <div className="tab-caption">{label}</div>
-      </div>
+      />
     );
   }
 

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -22,6 +22,7 @@ import {
   getFilterIdx,
 } from "../common/utilities.js";
 import { ToolbarButton } from "./controls/atoms/ToolbarButton";
+import { FullscreenToggle } from "./controls/FullScreenToggle";
 
 class Toolbar extends React.Component {
   constructor(props) {
@@ -298,6 +299,9 @@ class Toolbar extends React.Component {
                 panels.shapes.icon
               )
             : null}
+          {features.USE_FULLSCREEN && (
+            <FullscreenToggle language={this.props.language} />
+          )}
         </div>
         <BottomActions
           info={{

--- a/src/components/controls/FullScreenToggle.js
+++ b/src/components/controls/FullScreenToggle.js
@@ -1,0 +1,52 @@
+import React from "react";
+import screenfull from "screenfull";
+import { ToolbarButton } from "./atoms/ToolbarButton";
+import copy from "../../common/data/copy.json";
+
+export class FullscreenToggle extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.onFullscreenStateChange = this.onFullscreenStateChange.bind(this);
+
+    this.state = {
+      isFullscreen: screenfull.isFullscreen,
+    };
+  }
+
+  componentDidMount() {
+    screenfull.on("change", this.onFullscreenStateChange);
+  }
+
+  componentWillUnmount() {
+    screenfull.off("change", this.onFullscreenStateChange);
+  }
+
+  onFullscreenStateChange(evt) {
+    this.setState({ isFullscreen: screenfull.isFullscreen });
+  }
+
+  onToggleFullscreen() {
+    screenfull.toggle().catch(console.warn);
+  }
+
+  render() {
+    if (!screenfull.isEnabled) return null;
+
+    const { language } = this.props;
+    const { isFullscreen } = this.state;
+
+    return (
+      <ToolbarButton
+        isActive={isFullscreen}
+        label={
+          isFullscreen
+            ? copy[language].toolbar.fullscreen_exit
+            : copy[language].toolbar.fullscreen_enter
+        }
+        iconKey={isFullscreen ? "fullscreen_exit" : "fullscreen"}
+        onClick={this.onToggleFullscreen}
+      />
+    );
+  }
+}

--- a/src/components/controls/atoms/ToolbarButton.js
+++ b/src/components/controls/atoms/ToolbarButton.js
@@ -1,0 +1,12 @@
+export function ToolbarButton({ isActive, iconKey, onClick, label }) {
+  return (
+    <div
+      className={isActive ? "toolbar-tab active" : "toolbar-tab"}
+      key={iconKey}
+      onClick={onClick}
+    >
+      <i className="material-icons">{iconKey}</i>
+      <div className="tab-caption">{label}</div>
+    </div>
+  );
+}

--- a/src/scss/toolbar.scss
+++ b/src/scss/toolbar.scss
@@ -228,7 +228,6 @@
       display: block;
       text-align: center;
       font-size: $xsmall;
-      margin-top: -2px;
       letter-spacing: 0.05em;
     }
 


### PR DESCRIPTION
closes #7 

The feature is hidden behind a feature flag `USE_FULLSCREEN` and uses the copy file for translations.

This uses the popular [screenfull](https://github.com/sindresorhus/screenfull) library to deal with the (surprisingly still present) cross-browser differences in this API. I've reviewed the library code and it looks decent and is tiny so I think including it should be ok. Note that the lib is pinned to the `^5` version range since the `react-app` babel preset does not support ESM modules yet - which `^6` of the lib uses.

@breezykermo if this looks ok to you, I will upstream it with a PR as well.

![Screenshot from 2022-03-22 22-06-11](https://user-images.githubusercontent.com/1682504/159576037-e7f9bd22-11e6-4901-bcb4-e56c4ac1f077.png)

![Screenshot from 2022-03-22 22-05-57](https://user-images.githubusercontent.com/1682504/159576034-e917da6b-9cdc-4d85-978e-937dfa47f9a8.png)
