### PR TITLE
feat(map): add satellite overlay toggle

### DIFF
--- a/config.js
+++ b/config.js
@@ -2,11 +2,12 @@ const one_day = 1440;
 module.exports = {
   title: "ukraine",
   display_title: "Civilian Harm in Ukraine",
-  SERVER_ROOT: 'https://ukraine.bellingcat.com/ukraine-server',
+  SERVER_ROOT: "https://ukraine.bellingcat.com/ukraine-server",
   EVENTS_EXT: "/api/ukraine/export_events/deeprows",
   SOURCES_EXT: "/api/ukraine/export_sources/deepids",
   ASSOCIATIONS_EXT: "/api/ukraine/export_associations/deeprows",
-  MAPBOX_TOKEN: "pk.eyJ1IjoiYmVsbGluZ2NhdC1tYXBib3giLCJhIjoiY2tleW0wbWliMDA1cTJ5bzdkbTRraHgwZSJ9.GJQkjPzj8554VhR5SPsfJg",
+  MAPBOX_TOKEN:
+    "pk.eyJ1IjoiYmVsbGluZ2NhdC1tYXBib3giLCJhIjoiY2tleW0wbWliMDA1cTJ5bzdkbTRraHgwZSJ9.GJQkjPzj8554VhR5SPsfJg",
   // MEDIA_EXT: "/api/media",
   DATE_FMT: "MM/DD/YYYY",
   TIME_FMT: "HH:mm",
@@ -16,7 +17,7 @@ module.exports = {
       debug: true,
       map: {
         // anchor: [49.02421913, 31.43836003],
-        anchor: [48.3326259, 33.199514470],
+        anchor: [48.3326259, 33.19951447],
         maxZoom: 18,
         minZoom: 4,
         startZoom: 6,
@@ -24,7 +25,7 @@ module.exports = {
       },
       cluster: { radius: 50, minZoom: 5, maxZoom: 12 },
       associations: {
-        defaultCategory: "Weapon System"
+        defaultCategory: "Weapon System",
       },
       timeline: {
         dimensions: {
@@ -32,15 +33,12 @@ module.exports = {
           contentHeight: 150,
         },
         zoomLevels: [
-          { label: 'Zoom to 1 week', duration: 7 * one_day },
-          { label: 'Zoom to 2 weeks', duration: 14 * one_day },
-          { label: 'Zoom to 1 month', duration: 31 * one_day },
-          { label: 'Zoom to 3 months', duration: 3 * 31 * one_day },
+          { label: "Zoom to 1 week", duration: 7 * one_day },
+          { label: "Zoom to 2 weeks", duration: 14 * one_day },
+          { label: "Zoom to 1 month", duration: 31 * one_day },
+          { label: "Zoom to 3 months", duration: 3 * 31 * one_day },
         ],
-        range: [
-          new Date(Date.now() - (14 * (60 * 60 * 1000 * 24))),
-          new Date()
-        ],
+        range: [new Date(Date.now() - 14 * (60 * 60 * 1000 * 24)), new Date()],
         // rangeLimits: []
       },
       intro: [
@@ -71,8 +69,8 @@ module.exports = {
           "## A Note on Bellingcat's Global Authentication Project",
           "The Global Authentication Project consists of a wide community of open source researchers assisting in Bellingcat research through structured tasks and feedback. Our aim is to authenticate events taking place around the world and fill in the gaps of knowledge that exist, particularly in situations where there are vast quantities of data. In creating a community for those interested in open source research, we are fostering Bellingcat's original aim of solving problems **together**, to diversify our investigations and promote the use of these skills. For this dataset, we are working with many individuals who have Ukrainian language skills and others with local contextual knowledge of the events and places seen on the map. Other participants include individuals skilled in geolocation and chronolocation, with all contributions being vetted by Bellingcat researchers. As we expand the Global Authentication Project in the coming months, more information will be available on our website and Twitter.",
           "## Feedback",
-          "This map will continue to change and be updated for the duration of this conflict. We welcome feedback on our methodology,  data collection and take transparency seriously. Should you have any direct feedback about the platform, please indicate it on this [form](https://forms.gle/cV2YAojBoh6h4T3XA)."
-        ]
+          "This map will continue to change and be updated for the duration of this conflict. We welcome feedback on our methodology,  data collection and take transparency seriously. Should you have any direct feedback about the platform, please indicate it on this [form](https://forms.gle/cV2YAojBoh6h4T3XA).",
+        ],
       },
       toolbar: {
         panels: {
@@ -87,30 +85,43 @@ module.exports = {
             //   label: "Unverified",
             //   description: "todo",
             // }
-          }
-        }
+          },
+        },
       },
-      spotlights: {}
+      spotlights: {},
     },
     ui: {
       coloring: {
         mode: "STATIC",
         maxNumOfColors: 9,
         defaultColor: "#dfdfdf",
-        colors: ["#7E57C2", "#F57C00", "#FFEB3B", "#D34F73", "#08B2E3", "#A1887F", "#90A4AE", "#E57373", "#80CBC4"],
+        colors: [
+          "#7E57C2",
+          "#F57C00",
+          "#FFEB3B",
+          "#D34F73",
+          "#08B2E3",
+          "#A1887F",
+          "#90A4AE",
+          "#E57373",
+          "#80CBC4",
+        ],
       },
       card: {
         layout: {
-          template: "sourced"
-        }
+          template: "sourced",
+        },
       },
       carto: {
-        eventRadius: 8
+        eventRadius: 8,
       },
       timeline: {
-        eventRadius: 9
+        eventRadius: 9,
       },
-      tiles: 'bellingcat-mapbox/cl0qnou2y003m15s8ieuyhgsy'
+      tiles: {
+        current: "bellingcat-mapbox/cl0qnou2y003m15s8ieuyhgsy",
+        default: "bellingcat-mapbox/cl0qnou2y003m15s8ieuyhgsy",
+      },
     },
     features: {
       USE_CATEGORIES: false,
@@ -123,6 +134,7 @@ module.exports = {
       USE_SHAPES: false,
       USE_COVER: true,
       USE_INTRO: false,
+      USE_SATELLITE_OVERLAY_TOGGLE: true,
       USE_SEARCH: false,
       USE_SITES: false,
       ZOOM_TO_TIMEFRAME_ON_TIMELINE_CLICK: one_day,
@@ -130,7 +142,7 @@ module.exports = {
       USE_MEDIA_CACHE: false,
       GRAPH_NONLOCATED: false,
       NARRATIVE_STEP_STYLES: false,
-      CUSTOM_EVENT_FIELDS: []
+      CUSTOM_EVENT_FIELDS: [],
     },
   },
 };

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -400,3 +400,17 @@ export function fetchSourceError(msg) {
     msg,
   };
 }
+
+export const USE_SATELLITE_TILES_OVERLAY = "USE_SATELLITE_TILES_OVERLAY";
+export function useSatelliteTilesOverlay() {
+  return {
+    type: USE_SATELLITE_TILES_OVERLAY,
+  };
+}
+
+export const RESET_TILES_OVERLAY = "RESET_TILES_OVERLAY";
+export function resetTilesOverlay() {
+  return {
+    type: RESET_TILES_OVERLAY,
+  };
+}

--- a/src/common/data/copy.json
+++ b/src/common/data/copy.json
@@ -1,5 +1,9 @@
 {
   "es-MX": {
+    "tiles": {
+      "default": "Predeterminado",
+      "satellite": "Satélite"
+    },
     "loading": "Cargando...",
     "legend": {
       "view2d": {
@@ -90,6 +94,10 @@
     }
   },
   "en-US": {
+    "tiles": {
+      "default": "Default",
+      "satellite": "Satellite"
+    },
     "loading": "Loading...",
     "legend": {
       "view2d": {

--- a/src/components/space/carto/Map.js
+++ b/src/components/space/carto/Map.js
@@ -153,8 +153,6 @@ class Map extends React.Component {
     // Initialize supercluster index
     this.superclusterIndex = new Supercluster(clusterConfig);
 
-    this.initializeTileLayer(map);
-
     map.keyboard.disable();
     map.zoomControl.remove();
 

--- a/src/components/space/carto/Map.js
+++ b/src/components/space/carto/Map.js
@@ -573,7 +573,7 @@ function mapStateToProps(state) {
       },
     },
     ui: {
-      tiles: state.ui.tiles.current,
+      tiles: selectors.getTiles(state),
       dom: state.ui.dom,
       narratives: state.ui.style.narratives,
       mapSelectedEvents: state.ui.style.selectedEvents,

--- a/src/components/space/carto/Map.js
+++ b/src/components/space/carto/Map.js
@@ -104,6 +104,9 @@ class Map extends React.Component {
     }
   }
 
+  /**
+   * Initialize the base tile layer based on the ui state
+   */
   initializeTileLayer() {
     if (!this.map) {
       return;
@@ -136,7 +139,7 @@ class Map extends React.Component {
 
   initializeMap() {
     /**
-     * Creates a Leaflet map and a tilelayer for the map background
+     * Creates a Leaflet map
      */
     const { map: mapConfig, cluster: clusterConfig } = this.props.app;
 

--- a/src/components/space/carto/atoms/SatelliteOverlayToggle.js
+++ b/src/components/space/carto/atoms/SatelliteOverlayToggle.js
@@ -1,0 +1,40 @@
+import React from "react";
+import copy from "../../../../common/data/copy.json";
+import { language } from "../../../../common/utilities";
+
+const SatelliteOverlayToggle = ({
+  switchToSatellite,
+  reset,
+  isUsingSatellite,
+}) => {
+  return (
+    <div id="satellite-overlay-toggle" className="satellite-overlay-toggle">
+      <button
+        disabled={!isUsingSatellite}
+        id="satellite-overlay-toggle-default"
+        className={
+          !isUsingSatellite
+            ? "satellite-overlay-toggle-button-active"
+            : "satellite-overlay-toggle-button-inactive"
+        }
+        onClick={reset}
+      >
+        {copy[language].tiles.default}
+      </button>
+      <button
+        id="satellite-overlay-toggle-satellite"
+        className={
+          isUsingSatellite
+            ? "satellite-overlay-toggle-button-active"
+            : "satellite-overlay-toggle-button-inactive"
+        }
+        disabled={isUsingSatellite}
+        onClick={switchToSatellite}
+      >
+        {copy[language].tiles.satellite}
+      </button>
+    </div>
+  );
+};
+
+export default SatelliteOverlayToggle;

--- a/src/components/space/carto/atoms/__tests__/SatelliteOverlayToggle.spec.js
+++ b/src/components/space/carto/atoms/__tests__/SatelliteOverlayToggle.spec.js
@@ -1,0 +1,56 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import SatelliteOverlayToggle from "../SatelliteOverlayToggle";
+import "@testing-library/jest-dom";
+
+describe("<SatelliteOverlayToggle />", () => {
+  it("disables the currently selected default option", () => {
+    render(
+      <SatelliteOverlayToggle reset={jest.fn()} switchToSatellite={jest.fn()} />
+    );
+    expect(
+      screen.getByRole("button", { name: /satellite/i })
+    ).not.toBeDisabled();
+    expect(screen.getByRole("button", { name: /default/i })).toBeDisabled();
+  });
+
+  it("disables the currently selected satellite option", () => {
+    render(
+      <SatelliteOverlayToggle
+        isUsingSatellite
+        reset={jest.fn()}
+        switchToSatellite={jest.fn()}
+      />
+    );
+    expect(screen.getByRole("button", { name: /satellite/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /default/i })).not.toBeDisabled();
+  });
+
+  it("calls the reset function when switching to the default overlay", () => {
+    const mockReset = jest.fn();
+    const mockSat = jest.fn();
+    render(
+      <SatelliteOverlayToggle
+        isUsingSatellite
+        reset={mockReset}
+        switchToSatellite={mockSat}
+      />
+    );
+    const btn = screen.getByRole("button", { name: /default/i });
+    fireEvent.click(btn);
+    expect(mockReset).toHaveBeenCalledTimes(1);
+    expect(mockSat).not.toHaveBeenCalled();
+  });
+
+  it("calls the switchToSatellite function when switching to the satellite overlay", () => {
+    const mockReset = jest.fn();
+    const mockSat = jest.fn();
+    render(
+      <SatelliteOverlayToggle reset={mockReset} switchToSatellite={mockSat} />
+    );
+    const btn = screen.getByRole("button", { name: /satellite/i });
+    fireEvent.click(btn);
+    expect(mockSat).toHaveBeenCalledTimes(1);
+    expect(mockReset).not.toHaveBeenCalled();
+  });
+});

--- a/src/reducers/__tests__/ui.spec.js
+++ b/src/reducers/__tests__/ui.spec.js
@@ -1,0 +1,23 @@
+import { useSatelliteTilesOverlay, resetTilesOverlay } from "../../actions";
+import initial from "../../store/initial.js";
+import ui from "../ui";
+
+describe("UI reducer", () => {
+  it("can change the tiling", () => {
+    const result = ui(initial.ui, useSatelliteTilesOverlay());
+    expect(result.tiles.current).toEqual("satellite");
+    expect(result.tiles.default).toEqual(initial.ui.tiles.default);
+  });
+
+  it("can revert to the default tiling", () => {
+    const result = ui(
+      {
+        ...initial.ui,
+        tiles: { default: "some default", current: "something else" },
+      },
+      resetTilesOverlay()
+    );
+    expect(result.tiles.current).toEqual("some default");
+    expect(result.tiles.default).toEqual("some default");
+  });
+});

--- a/src/reducers/ui.js
+++ b/src/reducers/ui.js
@@ -1,9 +1,28 @@
 import initial from "../store/initial.js";
 
-import {} from "../actions";
+import { USE_SATELLITE_TILES_OVERLAY, RESET_TILES_OVERLAY } from "../actions";
 
 function ui(uiState = initial.ui, action) {
-  return uiState;
+  switch (action.type) {
+    case USE_SATELLITE_TILES_OVERLAY:
+      return {
+        ...uiState,
+        tiles: {
+          ...uiState.tiles,
+          current: "satellite",
+        },
+      };
+    case RESET_TILES_OVERLAY:
+      return {
+        ...uiState,
+        tiles: {
+          ...uiState.tiles,
+          current: uiState.tiles.default,
+        },
+      };
+    default:
+      return uiState;
+  }
 }
 
 export default ui;

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -13,3 +13,4 @@
 @import "mediaplayer";
 @import "cover";
 @import "search";
+@import "satelliteoverlaytoggle";

--- a/src/scss/satelliteoverlaytoggle.scss
+++ b/src/scss/satelliteoverlaytoggle.scss
@@ -1,0 +1,28 @@
+@import "variables";
+
+.satellite-overlay-toggle {
+  background-color: rgb(53, 53, 53);
+  opacity: 0.9;
+  position: fixed;
+  top: 4px;
+  left: 120px;
+  z-index: $map-overlay;
+}
+
+.satellite-overlay-toggle-button-active {
+  padding: 2px 4px 4px 4px;
+  border-style: none;
+  font-size: $small;
+  font-family: $mainfont;
+  background-color: rgb(53, 53, 53);
+  color: white;
+}
+
+.satellite-overlay-toggle-button-inactive {
+  padding: 2px 4px 4px 4px;
+  border-style: none;
+  font-size: $small;
+  font-family: $mainfont;
+  background-color: rgb(53, 53, 53);
+  color: rgb(159, 159, 159);
+}

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -39,6 +39,7 @@ export const getTimelineDimensions = (state) => state.app.timeline.dimensions;
 export const selectNarrative = (state) => state.app.associations.narrative;
 export const getFeatures = (state) => state.features;
 export const getEventRadius = (state) => state.ui.eventRadius;
+export const getTiles = (state) => state.ui.tiles.current;
 
 export const selectSites = createSelector(
   [getSites, getFeatures],

--- a/src/store/initial.js
+++ b/src/store/initial.js
@@ -149,7 +149,10 @@ const initial = {
    *   as well as dom elements to attach SVG
    */
   ui: {
-    tiles: "openstreetmap", // ['openstreetmap', 'streets', 'satellite']
+    tiles: {
+      current: "openstreetmap", // ['openstreetmap', 'streets', 'satellite']
+      default: "openstreetmap", // ['openstreetmap', 'streets', 'satellite']
+    },
     style: {
       categories: {
         default: global.fallbackEventColor,


### PR DESCRIPTION
This closes #4 by adding an overlay toggle that allows changing between the default overlay (as defined in the initial state / config.js) and a satellite overlay. This is behind the `USE_SATELLITE_OVERLAY_TOGGLE` feature flag.

I've had to do a small refactor by bringing the initialisation of the base tile layer out of the `initializeMap` method so that it can be called whenever the tiles overlay style gets updated.

This PR also adds some unit tests, although these are not currently run in CI as far as I can tell.

Comments very welcome both on styling (I went for something very simple) and technical approach.

![Kapture 2022-03-22 at 23 35 48](https://user-images.githubusercontent.com/40741030/159619213-9de3e77b-3a52-46a5-819e-a0204fa86d2e.gif)


