### PR TITLE
Fix warning about Tab and TabPanel

### DIFF
--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -4,7 +4,7 @@ import { bindActionCreators } from "redux";
 import * as actions from "../actions";
 import * as selectors from "../selectors";
 
-import { Tabs, TabPanel } from "react-tabs";
+import { Tabs, TabList, TabPanel } from "react-tabs";
 import FilterListPanel from "./controls/FilterListPanel";
 import CategoriesListPanel from "./controls/CategoriesListPanel";
 import ShapesListPanel from "./controls/ShapesListPanel";
@@ -127,7 +127,7 @@ class Toolbar extends React.Component {
         {Object.keys(catMap).map((type) => {
           const children = catMap[type];
           return (
-            <TabPanel>
+            <TabPanel key={type}>
               <CategoriesListPanel
                 categories={children}
                 activeCategories={this.props.activeCategories}
@@ -180,9 +180,10 @@ class Toolbar extends React.Component {
     }
   }
 
-  renderToolbarTab(_selected, label, iconKey) {
+  renderToolbarTab(_selected, label, iconKey, key) {
     return (
       <ToolbarButton
+        key={key}
         label={label}
         iconKey={iconKey}
         isActive={this.state._selected === _selected}
@@ -201,7 +202,8 @@ class Toolbar extends React.Component {
           return this.renderToolbarTab(
             idxs[key],
             panelCategories[key].label,
-            panelCategories[key].icon
+            panelCategories[key].icon,
+            key
           );
         })}
       </div>
@@ -215,14 +217,12 @@ class Toolbar extends React.Component {
     return (
       <div className={classes}>
         {this.renderClosePanel()}
-        <Tabs onSelect={() => null} selectedIndex={this.state._selected}>
-          {narratives && narratives.length !== 0
-            ? this.renderToolbarNarrativePanel()
-            : null}
-          {features.USE_CATEGORIES ? this.renderToolbarCategoriesPanel() : null}
-          {features.USE_ASSOCIATIONS ? this.renderToolbarFilterPanel() : null}
-          {features.USE_SHAPES ? this.renderToolbarShapePanel() : null}
-        </Tabs>
+        {narratives && narratives.length !== 0
+          ? this.renderToolbarNarrativePanel()
+          : null}
+        {features.USE_CATEGORIES ? this.renderToolbarCategoriesPanel() : null}
+        {features.USE_ASSOCIATIONS ? this.renderToolbarFilterPanel() : null}
+        {features.USE_SHAPES ? this.renderToolbarShapePanel() : null}
       </div>
     );
   }
@@ -275,33 +275,35 @@ class Toolbar extends React.Component {
           <p>{title}</p>
         </div>
         <div className="toolbar-tabs">
-          {narrativesExist
-            ? this.renderToolbarTab(
-                narrativesIdx,
-                panels.narratives.label,
-                panels.narratives.icon
-              )
-            : null}
-          {features.USE_CATEGORIES
-            ? this.renderToolbarCategoryTabs(categoryIdxs)
-            : null}
-          {features.USE_ASSOCIATIONS
-            ? this.renderToolbarTab(
-                filtersIdx,
-                panels.filters.label,
-                panels.filters.icon
-              )
-            : null}
-          {features.USE_SHAPES
-            ? this.renderToolbarTab(
-                shapesIdx,
-                panels.shapes.label,
-                panels.shapes.icon
-              )
-            : null}
-          {features.USE_FULLSCREEN && (
-            <FullscreenToggle language={this.props.language} />
-          )}
+          <TabList>
+            {narrativesExist
+              ? this.renderToolbarTab(
+                  narrativesIdx,
+                  panels.narratives.label,
+                  panels.narratives.icon
+                )
+              : null}
+            {features.USE_CATEGORIES
+              ? this.renderToolbarCategoryTabs(categoryIdxs)
+              : null}
+            {features.USE_ASSOCIATIONS
+              ? this.renderToolbarTab(
+                  filtersIdx,
+                  panels.filters.label,
+                  panels.filters.icon
+                )
+              : null}
+            {features.USE_SHAPES
+              ? this.renderToolbarTab(
+                  shapesIdx,
+                  panels.shapes.label,
+                  panels.shapes.icon
+                )
+              : null}
+            {features.USE_FULLSCREEN && (
+              <FullscreenToggle language={this.props.language} />
+            )}
+          </TabList>
         </div>
         <BottomActions
           info={{
@@ -329,8 +331,10 @@ class Toolbar extends React.Component {
         id="toolbar-wrapper"
         className={`toolbar-wrapper ${isNarrative ? "narrative-mode" : ""}`}
       >
-        {this.renderToolbarTabs()}
-        {this.renderToolbarPanels()}
+        <Tabs onSelect={() => null} selectedIndex={this.state._selected}>
+          {this.renderToolbarTabs()}
+          {this.renderToolbarPanels()}
+        </Tabs>
       </div>
     );
   }

--- a/src/components/controls/atoms/ToolbarButton.js
+++ b/src/components/controls/atoms/ToolbarButton.js
@@ -10,3 +10,6 @@ export function ToolbarButton({ isActive, iconKey, onClick, label }) {
     </div>
   );
 }
+
+// https://github.com/reactjs/react-tabs#set-tabsrole
+ToolbarButton.tabsRole = "Tab";


### PR DESCRIPTION
Complementary to https://github.com/bellingcat/ukraine-timemap/pull/18.

Fixes these warnings:

<img width="761" alt="Screenshot 2022-04-03 at 20 54 37" src="https://user-images.githubusercontent.com/810438/161446289-ccabf3a2-c66b-4e9b-8b73-0aecb4d1e518.png">

According to `react-tabs` docs, the `Tabs` component is expected to contain a `TabList` which contains `Tab`s. I've moved the `Tabs` up to include the tab buttons, and added `TabList` around them. Since buttons use a custom component rather than `Tab`, I've set [`tabsRole`](https://github.com/reactjs/react-tabs#set-tabsrole) on the custom component to suppress the warning.

Overall I'm not sure `react-tabs` is working properly in this project with respect to a11y, focus management, etc. I'm not able to tab through the tabs with keyboard, for example. That's something that might be worth looking at in a follow-up.