### PR TITLE
Improve dragging performance

### DIFF
--- a/src/components/time/atoms/Events.js
+++ b/src/components/time/atoms/Events.js
@@ -24,7 +24,7 @@ function renderDot(event, styles, props) {
   );
   return (
     <g
-      key={hash(event)}
+      key={event.id}
       className="timeline-event"
       onClick={props.onSelect}
       transform={`translate(${props.x}, ${props.y})`}

--- a/src/components/time/atoms/Events.js
+++ b/src/components/time/atoms/Events.js
@@ -6,7 +6,6 @@ import DatetimeTriangle from "./DatetimeTriangle";
 import DatetimePentagon from "./DatetimePentagon";
 import Project from "./Project";
 import ColoredMarkers from "../../atoms/ColoredMarkers";
-import hash from "object-hash";
 import {
   calcOpacity,
   getEventCategories,


### PR DESCRIPTION
Dragging is slow because on every render, we're recalculating hashes for all events in view. This is not good. It seems like all events have IDs so I'm changing the keys to be those IDs.

Before:

https://user-images.githubusercontent.com/810438/161448256-54989647-819b-4a5d-9747-9db5a9987f88.mov

After:


https://user-images.githubusercontent.com/810438/161448260-16e40d94-aac4-4930-ae20-5864dd324d57.mov

There are more places where `object-hash` is used for keys. I strongly recommend against it. When an ID is not available in the data, we can either generate it when fetching or use index (assuming events don't get reordered during usage, that's fine). I will take a pass at other places and try to remove hashing there as well separately.