### PR TITLE
Fix flashing on zoom

### DIFF
--- a/src/components/space/carto/Map.js
+++ b/src/components/space/carto/Map.js
@@ -2,6 +2,7 @@
 import { bindActionCreators } from "redux";
 import "leaflet";
 import React from "react";
+import { flushSync } from "react-dom";
 import { Portal } from "react-portal";
 import Supercluster from "supercluster";
 import { isMobileOnly } from "react-device-detect";
@@ -173,8 +174,10 @@ class Map extends React.Component {
       this.map.dragging.enable();
       this.map.doubleClickZoom.enable();
       this.map.scrollWheelZoom.enable();
-      this.alignLayers();
-      this.updateClusters();
+      flushSync(() => {
+        this.alignLayers();
+        this.updateClusters();
+      });
     });
     map.on("zoomstart", () => {
       if (this.svgRef.current !== null)


### PR DESCRIPTION
Fixes https://github.com/bellingcat/ukraine-timemap/issues/27. I introduced this in https://github.com/bellingcat/ukraine-timemap/pull/20. (Sorry.)

State updates are batched in React 18, so they're slightly delayed unless they're coming directly from user input (like clicking/typing/panning). We make the clusters visible in Leaflet `zoomend` event, which is not directly caused by user interaction. So to adjust their positions in time, we need to `flushSync` the corresponding state update.

I'm sending PR against this fork because https://github.com/forensic-architecture/timemap/pull/233 has not landed yet.

## Before


https://user-images.githubusercontent.com/810438/161874927-c994c445-2432-45f2-9863-b0c69829bb5f.mov

## After


https://user-images.githubusercontent.com/810438/161874938-593b6725-1d9b-4ae5-8932-76a6a3b129e9.mov

