### PR TITLE
fix: refresh visible markers after panning map

### DIFF
--- a/src/components/space/carto/Map.js
+++ b/src/components/space/carto/Map.js
@@ -168,6 +168,7 @@ class Map extends React.Component {
 
     map.on("moveend", () => {
       this.alignLayers();
+      this.updateClusters();
     });
 
     map.on("zoomend viewreset", () => {


### PR DESCRIPTION
This fixes a bug where clusters would not show after panning around the map. Clusters would only show up again after adjusting zoom.

I aligned the event handler with upstream where this error is not present.

### Before

https://user-images.githubusercontent.com/1682504/162472321-41cbd44f-c4ee-44f4-81ea-636528df101d.mp4

### After

https://user-images.githubusercontent.com/1682504/162472359-81e46707-86c3-449f-810a-a551228289f4.mp4


