### PR TITLE
fix: check for id presence in store during url rehydration

### DIFF
--- a/src/store/plugins/urlState/schema.js
+++ b/src/store/plugins/urlState/schema.js
@@ -50,9 +50,19 @@ export const SCHEMA = Object.freeze({
     // TODO: determine time range if `range` not set.
     rehydrate(nextState, { id }) {
       if (id?.length) {
-        nextState.app.selected = id.map((id) =>
-          nextState.domain.events.find((e) => e.id === id)
-        );
+        nextState.app.selected = id.reduce((acc, curr) => {
+          const event = nextState.domain.events.find((e) => e.id === curr);
+
+          if (event) {
+            acc.push(event);
+          } else {
+            console.warn(
+              `event ${curr} could not be rehydrated. reason: not present.`
+            );
+          }
+
+          return acc;
+        }, []);
       }
     },
   },


### PR DESCRIPTION
@loganwilliams @msramalho 

this fixes a bug present on the [live article](https://www.bellingcat.com/news/uk-and-europe/2022/10/24/the-remote-control-killers-behind-russias-cruise-missile-strikes-on-ukraine/).

The issue is that the url has two ids that are not present in the maps data sources (989, 990) which crashes the rehydration logic. This fixes the logic to ignore events that can't be found and emit a warning to the console instead. This way, the map stays usable with faulty URLs.