### PR TITLE
fix: allow de- & rehydration for timeline

### DIFF
--- a/src/store/plugins/urlState/schema.js
+++ b/src/store/plugins/urlState/schema.js
@@ -77,7 +77,14 @@ export const SCHEMA = Object.freeze({
       if (range?.length === 2) {
         const val = Array.from(range);
         val.sort((a, b) => new Date(a) - new Date(b));
-        nextState.app.timeline.range = val;
+        // HACK! diversion from upstream: we use a custom timeline state format.
+        nextState.app.timeline = {
+          ...nextState.app.timeline,
+          range: {
+            ...nextState.app.timeline.range,
+            current: val,
+          },
+        };
       }
     },
   },

--- a/src/store/plugins/urlState/urlState.js
+++ b/src/store/plugins/urlState/urlState.js
@@ -22,7 +22,13 @@ export class URLState {
 
     this.delete(key);
 
-    if (isSchemaArray(schema)) {
+    // HACK! diversion from upstream: we use a custom timeline state format.
+    if (schema.type === SCHEMA_TYPES.DATE_ARRAY) {
+      value.current.forEach((val) => {
+        const encoded = this._encode(schema, val);
+        if (encoded) this.url.searchParams.append(key, encoded);
+      });
+    } else if (isSchemaArray(schema)) {
       value.forEach((val) => {
         const encoded = this._encode(schema, val);
         if (encoded) this.url.searchParams.append(key, encoded);


### PR DESCRIPTION
https://github.com/bellingcat/ukraine-timemap/commit/a14ad2670ae69876b43619873f29a6a841dce24c introduced a custom format timeline format that is not reflected upstream. this fixes the rehydration plugin to be compatible with it.

both timeline and filters should now be correctly rehydrated from the url:

<img width="1439" alt="Screenshot 2022-10-24 at 22 19 35" src="https://user-images.githubusercontent.com/1682504/197621139-3e476c1b-a3e8-4d16-b4e4-67b701cf0c1b.png">
