### PR TITLE
fix(timeline): vertical labels on small viewports

### DIFF
--- a/src/scss/timeline.scss
+++ b/src/scss/timeline.scss
@@ -179,6 +179,15 @@
         text {
           fill: $midwhite;
           text-transform: capitalize;
+
+          @media screen and (max-width: 960px) {
+            writing-mode:vertical-lr;
+            /*
+             * Applies slightly different in Gecko and WebKit/Blink.
+             * Optimized for WebKit as its more common on mobile viewports.
+             */
+            transform: translateX(6px) translateY(6px);
+          }
         }
       }
 


### PR DESCRIPTION
Improves the display of timeline labels on mobile viewports. While not an optimal fix, it makes the labels readable in the majority of cases.

[Browser support for writing-mode](https://caniuse.com/css-writing-mode).

**Before**
<img width="500" alt="Screenshot 2023-01-28 at 14 29 31" src="https://user-images.githubusercontent.com/1682504/215268977-cb366e4d-43cc-4d3d-afd9-3e697256bf5b.png">

**After**
<img width="500" alt="Screenshot 2023-01-28 at 14 27 31" src="https://user-images.githubusercontent.com/1682504/215268984-de2c117e-9f5c-4939-a53d-8ee352f3ee43.png">
